### PR TITLE
Add now playing track number badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ I created this because:
 - Remembers shuffle and loop preferences between sessions (defaults: Shuffle On, Loop All).
 - Restores the last played track when available, otherwise falls back to the first track.
 - Offers optional voice announcements for track transitions with customizable voice selection.
+- Shows the current track number in the Now Playing header for quick reference.
 
 ## Speech Announcements
 - Toggle the `🗣 Announce` control (or press `A`) to enable spoken track transitions.
@@ -29,6 +30,7 @@ I created this because:
 - In the Utho Riley folder play “A Classical Approach…” and confirm the announcer says “Now playing, A Classical Approach, by Utho Riley.”
 - In White Bat Audio play “Free Sci-Fi Music…” and confirm it says “Now playing, Phobos Monolith, by White Bat Audio.”
 - Toggle speech off/on during playback to verify announcements resume without disturbing audio when disabled.
+- Start playback and confirm the Now Playing header shows the expected track number, updating as you skip forward or back.
 
 ## Media
 I use yt-dlp to download from YouTube playlists.

--- a/player.html
+++ b/player.html
@@ -81,8 +81,22 @@
     background: rgba(11, 18, 46, 0.84); border: 1px solid var(--border); border-radius: 14px; padding: 14px;
     box-shadow: 0 0 22px rgba(93, 251, 255, 0.08);
   }
-  .now small { color: var(--muted); display: block; margin-bottom: 6px; }
-  .now strong { display: block; font-size: 16px; line-height: 1.3; }
+  .now small {
+    color: color-mix(in srgb, var(--muted) 40%, var(--accent) 60%);
+    display: block; margin-bottom: 8px;
+    font-size: 16px; font-weight: 600; letter-spacing: .8px;
+  }
+  .now strong {
+    display: flex; align-items: center; gap: 12px;
+    font-size: 16px; line-height: 1.3;
+  }
+  .now-num {
+    min-width: var(--now-num-min, 4ch); font-variant-numeric: tabular-nums;
+    color: var(--accent); letter-spacing: .6px;
+    display: inline-flex; align-items: center; justify-content: center;
+    padding: 8px var(--now-num-pad-x, 12px); border-radius: 999px; border: 1px solid rgba(93, 251, 255, 0.28);
+    background: rgba(93, 251, 255, 0.12); font-weight: 600; line-height: 1;
+  }
   .controls {
     display: grid; grid-template-columns: repeat(auto-fit, minmax(var(--ctrl-min), 1fr)); gap: 10px;
   }
@@ -169,8 +183,11 @@
     <div class="wrap">
       <section class="player">
         <div class="now">
-          <small>Now Playing</small>
-          <strong id="nowTitle">—</strong>
+          <small>Now Playing:</small>
+          <strong>
+            <span id="nowTrackNumber" class="now-num">—</span>
+            <span id="nowTitle">—</span>
+          </strong>
         </div>
 
         <div class="controls" role="group" aria-label="Playback controls">
@@ -205,6 +222,7 @@
   const listEl      = document.getElementById('list');
   const audio       = document.getElementById('audio');
   const nowTitleEl  = document.getElementById('nowTitle');
+  const nowTrackNumberEl = document.getElementById('nowTrackNumber');
   const countEl     = document.getElementById('count');
 
   const prevBtn     = document.getElementById('prevBtn');
@@ -315,6 +333,22 @@
   let lastAnnouncedTrackKey = null;
   let announceTimer = null;
 
+  const applyNowTrackMetrics = () => {
+    if (!nowTrackNumberEl) return;
+    if (!tracks.length) {
+      nowTrackNumberEl.style.removeProperty('--now-num-min');
+      nowTrackNumberEl.style.removeProperty('--now-num-pad-x');
+      return;
+    }
+    const digits = Math.max(1, String(tracks.length).length);
+    const minCh = Math.max(4, digits + 1);
+    nowTrackNumberEl.style.setProperty('--now-num-min', `${minCh}ch`);
+    const padX = Math.min(26, 16 + Math.max(0, digits - 2) * 5);
+    nowTrackNumberEl.style.setProperty('--now-num-pad-x', `${padX}px`);
+  };
+
+  applyNowTrackMetrics();
+
   // Debounce delay for speech announcements.
   // 250ms prevents announcement spam during rapid track skipping,
   // and provides time for the audio to stabilize before speaking.
@@ -325,6 +359,11 @@
     if (!isFinite(s) || s < 0) s = 0;
     const m = Math.floor(s / 60), ss = Math.floor(s % 60);
     return `${m}:${ss.toString().padStart(2,'0')}`;
+  };
+  const fmtTrackNumber = (idx) => {
+    if (!tracks.length || idx < 0 || idx >= tracks.length) return '—';
+    const digits = Math.max(1, String(tracks.length).length);
+    return `#${String(idx + 1).padStart(digits, '0')}`;
   };
   const normalizeSpaces = (value) => {
     if (!value) return '';
@@ -591,7 +630,9 @@
     }
     revokeAll();
     listEl.innerHTML = '';
-    nowTitleEl.textContent = '—';
+    if (nowTitleEl) nowTitleEl.textContent = '—';
+    if (nowTrackNumberEl) nowTrackNumberEl.textContent = '—';
+    applyNowTrackMetrics();
     countEl.textContent = 'Scanning…';
 
     try {
@@ -611,9 +652,11 @@
     } catch (err) {
       console.error('Failed scanning folder', err);
       tracks = [];
+      applyNowTrackMetrics();
     }
 
     tracks.sort((a, b) => NAME_COLLATOR.compare(trackKey(a), trackKey(b)));
+    applyNowTrackMetrics();
 
     renderList();
     countEl.textContent = `${tracks.length} track${tracks.length===1?'':'s'}`;
@@ -807,7 +850,8 @@
     const tr = tracks[current];
     recordPendingAnnouncement(tr);
     audio.src = tr.url;
-    nowTitleEl.textContent = tr.displayName;
+    if (nowTitleEl) nowTitleEl.textContent = tr.displayName;
+    if (nowTrackNumberEl) nowTrackNumberEl.textContent = fmtTrackNumber(current);
     highlightActive();
     putStoreValue(LAST_TRACK_KEY, trackKey(tr)).catch(err => {
       console.error('Failed storing last track', err);


### PR DESCRIPTION
Fixes #8 

- Styled the Now Playing header to include a dedicated numeric badge that stays aligned with the title (player.html:85, player.html:204).
- Added track-number formatting logic so the badge reflects the current index and resets during rescans (player.html:633, player.html:889, player.html:1112).
- Documented the new indicator in the feature list and manual testing checklist (README.md:11,README.md:24, README.md:32).