### PR TITLE
Enable prev control when history exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,195 +1,83 @@
-
 # Local Web Audio Player
 
-Very boring name for now.
+Single-page MP3 folder player focused on fast local playback, rich listening history, and streamer-friendly tooling, all bundled into one `player.html`.
 
-I created this because:
-1. YouTube/YouTubeMusic plays way too many ads
-2. I did not like VLC very much
-3. I wanted to add a "Now playing ... That was ... " voice
+## Why This Exists
+- YouTube/YouTube Music insert too many ads.
+- VLC never quite fit the workflow.
+- Automatic “Now playing… That was…” voice callouts sounded fun.
 
-## Features
-- Remembers shuffle and loop preferences between sessions (defaults: Shuffle On, Loop All).
-- Restores the last played track when available, otherwise falls back to the first track.
-- Offers optional voice announcements for track transitions with customizable voice selection.
-- Shows the current track number in the Now Playing header for quick reference.
-- Includes selectable spectrum analyzer visualizations (Neon Bars, Glow Wave, Pulse Halo) with logarithmic frequency mapping for balanced display across the audible spectrum (20Hz-20kHz). The selector is disabled if the browser lacks AudioContext support.
-- Supports volume control via on-screen slider and Up/Down arrow keys (5% increments). Volume preference is persisted between sessions.
-- Integrates with OS media controls (Bluetooth headsets, keyboard media keys, system tray) via the Media Session API.
-- Logs every listening session with timestamps, duration heard, and automatic skip detection (<50% heard) that you can review from the History overlay (open it with the footer History button).
-- Tracks actual listening time (pauses excluded) so the history shows how much you truly heard; the % column turns yellow when you hear less than 100%, blue right at 100%, and green when rewinds push you beyond the original duration. When the filename includes a YouTube ID, the History overlay links straight back to the original video for quick reference.
-- **Track Ratings:** Rate each track with a 5-star system. Ratings are stored in IndexedDB and persist across sessions. Click any star to set a rating (1-5 stars), or click the current rating again to clear it.
-- **OBS Metadata Export:** Export "now playing" track metadata to a text file for use in OBS overlays and streaming software (Chromium browsers only).
+## Requirements & Browser Support
+- Chrome browser (not tested on any others). File System Access, Media Session, OBS export, and persistence rely on Chromium APIs.
+- All data stays local: IndexedDB stores folder handles, history (latest 500 sessions), track ratings, and preferences. The optional text export writes only to the file you pick.
+- Speech synthesis and AudioContext features gracefully degrade when unsupported; UI toggles reflect availability.
+
+## Getting Started
+1. Open `player.html` (`xdg-open player.html` on Linux or `open player.html` on macOS).
+2. Click **Choose Folder**, grant read access, and the playlist populates instantly.
+3. Use the footer **History** button to review sessions; open **⚙️ Settings** to configure the optional OBS text export.
+4. If the browser blocks direct file access, run `python3 -m http.server` and visit `http://localhost:8000/player.html`.
+
+## Core Features
+- **Persistent playback state** – Shuffle (defaults on), loop mode, volume, last track, and announcement preference survive reloads.
+- **Real-time history overlay:** Live row updates while a track plays, with per-entry delete, clear-all (with confirmation), and automatic pruning to the latest 500 sessions.
+- **Percent-heard insights** – Timers exclude paused time; badges highlight skips (<50%), completions (~100%), and rewinds (>100%).
+- **Track ratings** – Five-star ratings appear beside each track and within “Now Playing”, sync in both views, and persist locally.
+- **Announcements & speech** – Optional synthesized callouts with preferred-voice selection and debounced messaging.
+- **Media Session integration** – OS media keys, Bluetooth headsets, and system trays control playback and mirror metadata.
+- **Spectrum analyzers** – Neon Bars, Glow Wave, and Pulse Halo visualize 20 Hz–20 kHz with logarithmic mapping.
+- **Streamer tools:** Optional text export for OBS overlays plus Media Session integration and voice announcements.
+- **YouTube-friendly metadata:** Filenames ending in `[videoId]` gain direct links back to the source.
 
 ## Playback History
-
-The player now tracks each time you start or stop a song so you can understand how you actually listen:
-
-- Every play session records the start timestamp, track metadata, how many seconds you listened, and the percent of the track you heard.
-- Sessions that end before 50% completion are marked as **Skipped**, letting you instantly spot tracks you abandon.
-- History is stored locally in IndexedDB and survives page reloads; the most recent 500 sessions are retained automatically.
-- Open the **History** overlay (click the footer History button) to inspect your listening log. Each row shows when the track started, the path/artist, how long you listened, and whether it completed, was skipped, or manually stopped.
+- Each session records start/end timestamps, heard duration, percent played, skip detection, and rewind tagging.
+- A live history row mirrors the current track; completed sessions roll into IndexedDB with automatic pruning to the newest 500 entries.
+- Rows link to YouTube when filenames include `[videoId]`, offer per-entry deletion, and support bulk clear with confirmation.
 
 ## Track Ratings
-
-Rate your favorite tracks with a 5-star rating system to quickly identify music you love.
-
-### How It Works
-- Each track in the playlist shows 5 star icons (★) next to its duration
-- **The currently playing track also displays stars in the "Now Playing" section** between the seek bar and time display
-- Click any star to rate the track from 1 to 5 stars
-- Click the same star again to clear the rating
-- Filled gold stars (★) indicate the current rating
-- Empty gray stars indicate unrated positions
-- Ratings are stored locally in IndexedDB and persist across sessions
-- Ratings are tied to the track's file path, so they remain even if you rescan the folder
-- Rating the current track in "Now Playing" updates both displays simultaneously
-
-### Use Cases
-- Quickly spot your favorite tracks in large folders
-- **Rate tracks on-the-fly while listening** without scrolling through the playlist
-- Build a personal preference database for future features (sorting, filtering, playlists)
-- Track which songs resonate with you over time
-
-### Data Storage
-- Ratings are stored in your browser's IndexedDB (not in MP3 ID3 tags)
-- No external services or cloud storage involved
-- Ratings remain private to your browser and device
-- To export ratings to ID3 tags, a future offline script may be provided
+- Click any of the five stars shown beside playlist rows or within the “Now Playing” panel to rate from one to five; clicking the active star clears the rating.
+- Filled gold stars indicate the current rating; grey outlines mark unrated positions and highlight on hover.
+- Ratings persist in IndexedDB, keyed by the track’s relative path, so they survive reloads and rescans of the same folder.
+- Updates stay in sync between the playlist and “Now Playing”, and rating interactions never interrupt playback.
 
 ## OBS Metadata Export
-
-Export currently playing track metadata to a text file that updates automatically for use in OBS overlays, streaming software, or other applications.
-
-### How to Use
-1. Click the **⚙️ Settings** button in the top-right corner
-2. In the settings modal, click **Configure** under "Text File Export"
-3. Choose or create a text file (e.g., `now-playing.txt`)
-4. The file updates automatically with `Title – Artist` while playback is active; it stays blank when tracks are paused or stopped
-5. **The file is cleared (emptied) when:**
-   - Playback is paused
-   - Playback stops at the end of the playlist (with loop off)
-   - A new folder is being scanned
-
-### In OBS Studio
-1. Add a **Text (GDI+)** source (or **Text (FreeType 2)** on Linux/macOS)
-2. Enable **"Read from file"**
-3. Browse to the text file you configured in the player
-4. Customize the text appearance (font, color, effects) as desired
-5. The text will update automatically as tracks play
-
-### Browser Requirements
-- **Supported:** Chromium-based browsers (Chrome, Edge, Opera, Brave)
-- **Not supported:** Firefox, Safari (they lack File System Access API for persistent file writes)
-- The feature gracefully detects unsupported browsers and shows an appropriate message
-
-### Disabling
-Click **⚙️ Settings** → **Disable** to stop exporting. You can re-enable it anytime without reconfiguring the file.
-
-### Troubleshooting
-- If the file stops updating, browser permissions may have been revoked. Re-open Settings and click **Configure** again.
-- Export failures appear as toast notifications (bottom-right) and are logged to the console without interrupting playback.
+- Configure once via **⚙️ Settings** → **Configure** to pick a text file (e.g., `now-playing.txt`). The player validates write access automatically.
+- While playback is active the file contains `Title – Artist`; it clears on pause, at the end of queues (loop off), or during folder scans.
+- Reloading retains export if permission persists; Settings shows “Active – filename.txt”. Unsupported browsers surface a toast explaining the limitation.
+- To use in OBS Studio, add a Text source, enable “Read from file”, point at the export, and style as desired. Disable the feature from Settings to stop updates.
 
 ## Speech Announcements
-- Toggle the `🗣 Announce` control (or press `A`) to enable spoken track transitions.
-- The player prefers the `Daniel (English (United Kingdom))` voice and falls back to the first available English voice exposed by your browser.
-- To prefer a different voice, tweak the `PREFERRED_VOICE_NAMES` list in `player.html`.
-- Folder-specific naming quirks can be handled by adding cases to the `ANNOUNCE_RULES` array in `player.html`.
-- Manual track skips (Next/Prev buttons, arrow keys, OS media controls) announce "Skipped track name. Now playing ...".
-- Automatic transitions (track ending naturally) announce "That was track name. Now playing ...".
-- When speech synthesis is unavailable the control is disabled; playback continues silently.
-
-## Manual Testing
-- Toggle Shuffle or Loop, reload `player.html`, and confirm the controls restore to their previous selections (initial defaults: Shuffle On, Loop All).
-- Start a track, reload `player.html`, and verify the same track is selected; if you remove or rename it, the player should open with the first track (or a random one if Shuffle is enabled).
-- **Track Ratings:** Load a music folder and verify each track displays 5 gray star icons (★) next to the duration.
-- **Track Ratings:** Click the third star on a track and verify the first three stars become filled with gold color and glow effect.
-- **Track Ratings:** Click the third star again (the current rating) and verify all stars become gray (rating cleared).
-- **Track Ratings:** Rate several tracks with different star counts (1-5 stars), reload the page, rescan the same folder, and verify all ratings persist correctly.
-- **Track Ratings:** Verify clicking a star does not trigger track playback (only plays when clicking the track name/number/duration).
-- **Track Ratings:** Hover over stars and verify they highlight with gold color and scale up slightly.
-- **Track Ratings (Now Playing):** Start playback and verify the "Now Playing" section shows 5 star icons between the seek bar and time display.
-- **Track Ratings (Now Playing):** Click the fourth star in "Now Playing" and verify both the "Now Playing" stars and the playlist item stars update simultaneously.
-- **Track Ratings (Now Playing):** Rate a track from "Now Playing", skip to a different track, then return to the first track and verify the rating persists.
-- **Track Ratings (Now Playing):** Verify the "Now Playing" rating updates automatically when using Next/Previous buttons or clicking a different track.
-- Start playback, open the **History** overlay, and confirm a new row appears with the correct start time, track info, and listened duration.
-- Skip a track before it reaches the halfway point and verify the history entry is labeled **Skipped** with a percent heard below 50%.
-- Play a track through without rewinding and confirm the % heard badge lands on a blue **100%** (±1%).
-- Skip ahead during playback so you listen to less than the full duration and verify the % heard badge remains yellow (<100%).
-- Rewind to rehear parts of the song and confirm the % heard badge turns green once you exceed 100% listened.
-- In the History overlay, click the linked path for a track whose filename contains a YouTube ID (e.g., `[abc123]`) and verify it opens the corresponding video in a new tab.
-- Delete a single history row via the **Delete** action and confirm it disappears after confirmation.
-- Use the **Clear** button in the History overlay, confirm the prompt, and verify all stored entries are removed while the overlay remains open.
-- Let a track play to completion, reload the page, and confirm the completed entry persists in the History overlay with the correct timestamp and duration data.
-- Load an MP3 folder, start playback, and confirm the announcer introduces the first track.
-- Press Next or Previous and listen for "Skipped track name ... Now playing ..." transition.
-- Let a track complete naturally and listen for "That was track name ... Now playing ..." transition.
-- Use arrow keys (←/→) to skip tracks and confirm "Skipped" messaging.
-- Use OS media controls (Bluetooth headset, keyboard media keys) to skip tracks and confirm "Skipped" messaging.
-- Turn `🗣 Announce` off, verify no further transitions are spoken, then turn it back on and change tracks to hear the announcer again.
-- In the Utho Riley folder play “A Classical Approach…” and confirm the announcer says “Now playing, A Classical Approach, by Utho Riley.”
-- In White Bat Audio play “Free Sci-Fi Music…” and confirm it says “Now playing, Phobos Monolith, by White Bat Audio.”
-- Toggle speech off/on during playback to verify announcements resume without disturbing audio when disabled.
-- Start playback and confirm the Now Playing header shows the expected track number, updating as you skip forward or back.
-- Start playback, open the Spectrum Analyzer selector, and confirm Neon Bars, Glow Wave, and Pulse Halo update live without interrupting audio. Pause playback and ensure the visualization stops animating until playback resumes.
-- Adjust volume with the slider and confirm audio volume changes accordingly.
-- Press Up arrow key to increase volume by 5%; press Down arrow key to decrease volume by 5%.
-- Reload the page and confirm the volume setting is restored.
-- Test that Up/Down arrow keys work when the player has focus, but do not interfere with scrolling behavior in the track list or other elements.
-- Resize the window on desktop and confirm the playlist column widens to show longer filenames, then shrink below 900px and ensure the layout collapses into a single column without horizontal scrolling.
-- Start playback and press keyboard media keys (Play/Pause, Next, Previous) or use Bluetooth headset controls to verify they control playback.
-- Check your OS media overlay (system tray, notification center, lock screen) and confirm it displays current track title and artist information.
-- **OBS Export:** Click Settings, configure a text file, load a music folder, start playback, and verify the text file contains "Title – Artist". Skip tracks and confirm the file updates automatically.
-- **OBS Export:** With export enabled, reload the page and verify export is still active (Settings should show "Active – filename.txt").
-- **OBS Export:** Click Disable in Settings, skip tracks, and verify the file no longer updates. Re-enable and verify updates resume.
-- **OBS Export (Firefox/Safari):** Open Settings and verify the Configure button shows an error toast about unsupported browser when clicked.
-
-## OS Media Controls
-
-The player integrates with your operating system's media controls using the Media Session API, allowing you to:
-
-- **Control playback from anywhere**: Use Bluetooth headset buttons, keyboard media keys, or your OS media tray (Windows taskbar, macOS control center, mobile lock screen) to play, pause, skip tracks, or seek without switching to the browser tab.
-- **View current track info**: The system media overlay displays the currently playing track's title, artist, and album (folder name).
-- **Supported actions**: Play, Pause, Previous Track, Next Track, Seek Forward, Seek Backward, and Seek to Position.
-
-### Browser Compatibility
-
-The Media Session API is supported in modern Chromium-based browsers (Chrome, Edge, Opera) and Firefox. On unsupported browsers, the feature gracefully degrades—the player continues to work normally but without OS-level media control integration.
-
-No special permissions or browser flags are required; the feature works automatically when supported.
+- Toggle the `🗣 Announce` control (or press `A`) to enable spoken track transitions; the preferred voice is “Daniel”, with fallbacks to other English voices.
+- Manual skips announce “Skipped …” while automatic transitions announce “That was …”. The feature disables itself when speech synthesis is unavailable.
 
 ## Spectrum Analyzer
+- Modes: **Neon Bars** (frequency bars), **Glow Wave** (oscilloscope), **Pulse Halo** (radial visualization).
+- Renders 20 Hz–20 kHz using logarithmic frequency spacing and −100 dBFS to 0 dBFS amplitude range. The selector hides when `AudioContext` is unavailable.
+- Validation media in `testmedia/`: high-frequency tones (16–20 kHz), white noise, and a 20–20 000 Hz sweep exercise each mode.
 
-The spectrum analyzer visualizations use logarithmic frequency mapping to provide a balanced view of the audio spectrum:
+## OS Media Controls
+- Media Session handlers mirror play, pause, previous, next, seek forward/backward, and seek-to actions from hardware keys and system trays.
+- Metadata (title, artist, album/folder) stays synchronized with lock screens and notification centers. Unsupported browsers simply ignore the hooks.
 
-- **Frequency Range**: Displays 20 Hz to 20 kHz, the full range of human hearing.
-- **Logarithmic Mapping**: Frequencies are mapped logarithmically rather than linearly, ensuring that bass, mids, and treble are all visible and proportional. This means that high-frequency content (like cymbals, hi-hats, and test tones at 16-20 kHz) will be clearly visible.
-- **Dynamic Range**: Uses -100 to 0 dBFS for amplitude, providing good sensitivity to both quiet and loud sounds.
-- **Visualization Modes**:
-  - **Neon Bars**: Vertical bars showing frequency distribution
-  - **Glow Wave**: Oscilloscope-style waveform display
-  - **Pulse Halo**: Radial frequency visualization
+## Manual Smoke Checks
+- **Playback basics:** Load a folder, start playback, toggle shuffle/loop, adjust volume via slider and arrow keys, seek, then reload to confirm preferences persist.
+- **History & ratings:** Watch the live history row while playing, pausing, and seeking; Skip forward a few tracks, then step backward with **Prev** until history exhausts; rate several tracks (in playlist and “Now Playing”), reload, and verify ratings persist without triggering playback; Delete a single history row and use **Clear**—both should confirm before removing data.
+- **Percent badges & links:** Finish a track, stop before halfway, and rewind past 100% to observe badge colors; open a history row that embeds a `[videoId]` and confirm the YouTube link resolves.
+- **Streamer workflow:** Enable OBS export, verify the text file updates, pause/stop to ensure it clears, reload to confirm the export remains active, then disable and ensure updates cease.
+- **Layout & accessibility:** Resize below 900 px to confirm the interface collapses cleanly; scroll large libraries while testing keyboard navigation; toggle announcements off/on to validate speech handling.
+- **OS integration & analyzer:** Use Bluetooth or hardware media keys for transport control and check the system media overlay; exercise the spectrum modes with tones, noise, and sweeps from `testmedia/`.
+- **Browser fallback:** Launch in a non-Chromium browser to confirm informative errors for folder picking or OBS export; revoke folder permission and ensure the app re-prompts gracefully.
 
-### Testing the Analyzer
+## Media Downloads
+`yt-dlp` command used to build local libraries:
 
-The `testmedia` folder contains test tones and noise files that can verify the analyzer's accuracy:
-
-- **High-Frequency Test Tones**: Files like `16000 Hz Test Tone [K15bC8w5MrA].mp3`, `18000 Hz Test Tone [3tBI-T2SQgQ].mp3`, and `20000 Hz Test Tone [0DyVytR5aO4].mp3` should appear in the high-frequency region (right side) of the spectrum.
-- **White Noise**: `White Noise [IMRj1ombxqY].mp3` should show activity across the entire frequency range when played at full volume, with relatively even distribution on Neon Bars and Pulse Halo modes.
-- **Frequency Sweep**: `20 - 20,000 Hz Audio Sweep ｜ Range of Human Hearing [PAsMlDptjx8].mp3` should show activity moving progressively from left (low) to right (high) across the spectrum.
-
-## Media
-I use yt-dlp to download from YouTube playlists.
-
-The general command is:
 ```
 yt-dlp -x --audio-format mp3 {URL}
 ```
 
-Examples:
-* My `Utho Riley` playlist: yt-dlp -x --audio-format mp3 PLNtyAG9UO9oeMDT193y8Zno_E8U4MMtIU
-* My `White Bat Audio` playlist: yt-dlp -x --audio-format mp3 PLNtyAG9UO9odGA1KzBuVsern15RexNfjQ
-* `GMODISM` `Test Your Speakers⧸Headphone Sound Test`: yt-dlp -x --audio-format mp3 5Dc-5DD8P-0
-* `Sonic Electronix` `Test Tones` playlist: yt-dlp -x --audio-format mp3 PLzFvCAfIq7a2SIBfDhpCytfJ4RHVb_KLY
+- `Utho Riley` playlist: `yt-dlp -x --audio-format mp3 PLNtyAG9UO9oeMDT193y8Zno_E8U4MMtIU`
+- `White Bat Audio` playlist: `yt-dlp -x --audio-format mp3 PLNtyAG9UO9odGA1KzBuVsern15RexNfjQ`
+- `GMODISM – Test Your Speakers / Headphone Sound Test`: `yt-dlp -x --audio-format mp3 5Dc-5DD8P-0`
+- `Sonic Electronix – Test Tones`: `yt-dlp -x --audio-format mp3 PLzFvCAfIq7a2SIBfDhpCytfJ4RHVb_KLY`
 
-### TODO
+## TODO

--- a/player.html
+++ b/player.html
@@ -157,6 +157,11 @@
     outline: 2px solid color-mix(in oklab, var(--accent) 70%, transparent); box-shadow: 0 0 24px rgba(93, 251, 255, 0.35);
   }
   button.ctrl:hover { border-color: rgba(93, 251, 255, 0.45); box-shadow: 0 0 26px rgba(93, 251, 255, 0.45); transform: translateY(-1px); }
+  button.ctrl:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+    pointer-events: none;
+  }
   .seek {
     display: grid; grid-template-columns: 1fr auto auto; align-items: center; gap: 10px; margin-top: 4px;
   }
@@ -267,7 +272,6 @@
   .now-rating .star.filled { color: #ffd700; text-shadow: 0 0 8px rgba(255, 215, 0, 0.6); }
   .now-rating .star.hover-fill { color: #ffd700; }
   .now-rating .star:hover { transform: scale(1.15); }
-
 
   .list {
     padding: 12px; overflow: auto; max-height: 610px;
@@ -950,6 +954,7 @@
   const loadHistoryEntries = async () => {
     try {
       historyEntries = await fetchRecentHistory(HISTORY_RENDER_LIMIT);
+      rebuildBackStackFromHistory();
       requestHistoryRender();
     } catch (err) {
       console.error('Failed loading playback history', err);
@@ -1004,6 +1009,103 @@
   let liveHistoryEntry = null;
   let historyRenderScheduled = false;
   let activeSession = null;
+  const playbackBackStack = [];
+  let suppressBackStackPush = false;
+  // Back stack tracks prior playback history. Initial population is capped by the render set,
+  // but the higher limit keeps room for additional runtime entries as the session continues.
+  const BACK_STACK_LIMIT = HISTORY_MAX_ENTRIES;
+
+  const trackIndexFromKey = (key) => {
+    if (!key || !tracks.length) return -1;
+    return tracks.findIndex(track => trackKey(track) === key);
+  };
+
+  const peekBackStackEntry = ({ allowUnresolved = false } = {}) => {
+    const hasTracks = tracks.length > 0;
+    for (let i = playbackBackStack.length - 1; i >= 0; i--) {
+      const entry = playbackBackStack[i];
+      if (!entry || !entry.trackKey) {
+        playbackBackStack.splice(i, 1);
+        continue;
+      }
+      if (!hasTracks) {
+        if (allowUnresolved) {
+          return { entry, index: -1, stackIndex: i };
+        }
+        return null;
+      }
+      const idx = trackIndexFromKey(entry.trackKey);
+      if (idx >= 0) {
+        return { entry, index: idx, stackIndex: i };
+      }
+      playbackBackStack.splice(i, 1);
+    }
+    return null;
+  };
+
+  const updatePrevButtonState = () => {
+    if (!prevBtn) return;
+    const candidate = peekBackStackEntry({ allowUnresolved: !tracks.length });
+    const hasHistory = Boolean(candidate);
+    prevBtn.disabled = !hasHistory;
+  };
+
+  const pushBackStackEntry = (entry) => {
+    if (!entry || !entry.trackKey) return;
+    playbackBackStack.push({
+      trackKey: entry.trackKey,
+      startedAt: entry.startedAt ?? Date.now(),
+    });
+    if (playbackBackStack.length > BACK_STACK_LIMIT) {
+      playbackBackStack.shift();
+    }
+    updatePrevButtonState();
+  };
+
+  const consumeBackStackEntry = () => {
+    const candidate = peekBackStackEntry();
+    if (!candidate) return null;
+    playbackBackStack.splice(candidate.stackIndex, 1);
+    updatePrevButtonState();
+    return candidate;
+  };
+
+  const clearPlaybackBackStack = () => {
+    playbackBackStack.length = 0;
+    updatePrevButtonState();
+  };
+
+  const removeBackStackEntry = (entry) => {
+    if (!entry || !entry.trackKey) return;
+    const { trackKey: key, startedAt } = entry;
+    for (let i = playbackBackStack.length - 1; i >= 0; i--) {
+      const candidate = playbackBackStack[i];
+      if (!candidate) continue;
+      if (candidate.trackKey !== key) continue;
+      if (typeof startedAt === 'number' && candidate.startedAt !== startedAt) continue;
+      playbackBackStack.splice(i, 1);
+    }
+    updatePrevButtonState();
+  };
+
+  const rebuildBackStackFromHistory = () => {
+    playbackBackStack.length = 0;
+    if (!Array.isArray(historyEntries) || !historyEntries.length) {
+      updatePrevButtonState();
+      return;
+    }
+    const maxBacklog = Math.min(historyEntries.length, BACK_STACK_LIMIT);
+    for (let i = historyEntries.length - 1; playbackBackStack.length < maxBacklog && i >= 0; i--) {
+      const entry = historyEntries[i];
+      if (!entry || !entry.trackKey) continue;
+      playbackBackStack.push({
+        trackKey: entry.trackKey,
+        startedAt: entry.startedAt ?? Date.now(),
+      });
+    }
+    updatePrevButtonState();
+  };
+  updatePrevButtonState();
 
   /** Media Session API support */
   const mediaSessionSupported = 'mediaSession' in navigator;
@@ -1065,10 +1167,20 @@
         }
       });
       navigator.mediaSession.setActionHandler('previoustrack', () => {
-        if (tracks.length) playIndex(prevIndex(), { autoplay: true, skipReason: 'manual' });
+        Promise.resolve(
+          playPreviousFromHistory({ autoplay: true })
+        ).catch(err => {
+          console.error('Failed handling previous track action', err);
+        });
       });
       navigator.mediaSession.setActionHandler('nexttrack', () => {
-        if (tracks.length) playIndex(nextIndex(), { autoplay: true, skipReason: 'manual' });
+        if (tracks.length) {
+          Promise.resolve(
+            playIndex(nextIndex(), { autoplay: true, skipReason: 'manual' })
+          ).catch(err => {
+            console.error('Failed handling next track action', err);
+          });
+        }
       });
       navigator.mediaSession.setActionHandler('seekbackward', (details) => {
         if (!isFinite(audio.duration) || audio.duration <= 0) return;
@@ -1697,6 +1809,7 @@
           try {
             await deleteHistoryEntryById(entry.id);
             historyEntries = historyEntries.filter(item => item.id !== entry.id);
+            removeBackStackEntry(entry);
             requestHistoryRender();
           } catch (err) {
             console.error('Failed deleting history entry', err);
@@ -1973,8 +2086,11 @@
     // - Above REWIND_RATIO_THRESHOLD (100.5%) counts as a rewind because listeners replayed a portion.
     // - Between SKIP_THRESHOLD and ~100% is treated as a normal completion.
     // - Below SKIP_THRESHOLD is classified as a fast-forward/skip.
+    const isHistoryBack = reason === 'history-back';
     let finalReason = reason;
-    if (percentPlayed !== null) {
+    if (isHistoryBack) {
+      finalReason = 'rewound';
+    } else if (percentPlayed !== null) {
       if (isRewoundPercent(percentPlayed)) {
         finalReason = 'rewound';
       } else if (percentPlayed >= SKIP_THRESHOLD) {
@@ -2002,6 +2118,9 @@
       skipped,
       reason: finalReason,
     };
+    if (!suppressBackStackPush && !isHistoryBack) {
+      pushBackStackEntry(entry);
+    }
     liveHistoryEntry = null;
     requestHistoryRender();
     activeSession = null;
@@ -2420,6 +2539,7 @@
       playIndex(targetIdx, {autoplay:false});
     }
     setFolderPath(dirHandle);
+    updatePrevButtonState();
   }
 
   if (announceBtn) {
@@ -2756,17 +2876,24 @@
     return idx;
   }
 
-  function prevIndex() {
-    if (!tracks.length) return current;
-    if (shuffle && tracks.length > 1) {
-      let idx;
-      do { idx = Math.floor(Math.random() * tracks.length); } while (idx === current);
-      return idx;
+  const playPreviousFromHistory = async ({ autoplay = true } = {}) => {
+    if (!tracks.length) return;
+    const candidate = consumeBackStackEntry();
+    if (!candidate) {
+      updatePrevButtonState();
+      return;
     }
-    let idx = current - 1;
-    if (idx < 0) idx = tracks.length - 1;
-    return idx;
-  }
+    suppressBackStackPush = true;
+    try {
+      await playIndex(candidate.index, { autoplay, skipReason: 'history-back' });
+    } catch (err) {
+      playbackBackStack.splice(candidate.stackIndex, 0, candidate.entry);
+      updatePrevButtonState();
+      throw err;
+    } finally {
+      suppressBackStackPush = false;
+    }
+  };
 
   const loadPreferences = async () => {
     try {
@@ -2831,6 +2958,7 @@
       try {
         await clearHistoryStore();
         historyEntries = [];
+        clearPlaybackBackStack();
         requestHistoryRender();
       } catch (err) {
         console.error('Failed clearing history entries', err);
@@ -2906,7 +3034,11 @@
   });
 
   nextBtn.addEventListener('click', () => playIndex(nextIndex(), {autoplay:true, skipReason:'manual'}));
-  prevBtn.addEventListener('click', () => playIndex(prevIndex(), {autoplay:true, skipReason:'manual'}));
+  prevBtn.addEventListener('click', () => {
+    playPreviousFromHistory({ autoplay: true }).catch(err => {
+      console.error('Failed loading previous track from history', err);
+    });
+  });
 
   shuffleBtn.addEventListener('click', () => {
     shuffle = !shuffle;
@@ -3037,7 +3169,7 @@
       if (e.metaKey || e.ctrlKey) {
         // Cmd/Ctrl + Left → previous track
         e.preventDefault();
-        prevBtn.click();
+        if (!prevBtn.disabled) prevBtn.click();
       } else {
         // Plain Left → seek backward 5 seconds
         // Only prevent default if not focused on a horizontally scrollable playlist


### PR DESCRIPTION
  - Added a guarded playback back stack so the Previous control and media-session handler pull from real listening history, keep entries across reloads, and only disable when the stack is empty (player.html:928, player.html:951, player.html:997, player.html:2677).
  - Prevented folder rescans from dropping history navigation by refreshing the button state once tracks have been rebuilt (player.html:2380).
  - Rewrote the README with a cleaner intro, consolidated setup/feature guidance, and updated manual smoke checks